### PR TITLE
feat: 付録（Appendix）のアルファベット章番号に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,21 @@ class: preface
 | あとがき | `afterword` |
 | 奥付 | `colophon` |
 | 表紙 | `cover` |
+| 付録 | `appendix` |
+
+### 付録（Appendix）
+
+付録として章番号をアルファベット（A, B, C...）にするには、frontmatter で `class: appendix` を指定する。
+
+```yaml
+---
+class: appendix
+body:
+  style: "counter-set: chapter 0;"
+---
+```
+
+`counter-set: chapter 0` の場合、h1 で A になる。`counter-set: chapter 1` の場合は B になる。図・表・数式の番号も自動的にアルファベット形式（例: 図A.-1）となる。扉ページの章番号は HTML に直接「A」等を記述する。
 
 ### 見出し
 

--- a/config/themes/techbook/theme.css
+++ b/config/themes/techbook/theme.css
@@ -865,3 +865,54 @@ body.afterword h2::before {
 .chapter-opening {
   page: chapter-opening;
 }
+
+/* 付録（Appendix） - 章番号をアルファベットで表示 */
+.appendix h1,
+body.appendix h1 {
+  string-set: chapter-header counter(chapter, upper-alpha) ". " content(text);
+}
+
+.appendix h1::before,
+body.appendix h1::before {
+  content: counter(chapter, upper-alpha) ". ";
+}
+
+/* 付録の表番号 */
+.appendix section.level1 > p:has(+ table)::before {
+  content: "表" counter(chapter, upper-alpha) ".-" counter(table) ": ";
+}
+.appendix section.level2 > p:has(+ table)::before {
+  content: "表" counter(chapter, upper-alpha) "." counter(section) ".-" counter(table) ": ";
+}
+.appendix section.level3 > p:has(+ table)::before {
+  content: "表" counter(chapter, upper-alpha) "." counter(section) "." counter(subsection) ".-" counter(table) ": ";
+}
+.appendix section.level4 > p:has(+ table)::before {
+  content: "表" counter(chapter, upper-alpha) "." counter(section) "." counter(subsection) "." counter(subsubsection) ".-" counter(table) ": ";
+}
+
+/* 付録の図番号 */
+.appendix section.level1 > figure > figcaption::before {
+  content: "図" counter(chapter, upper-alpha) ".-" counter(figure) ": ";
+}
+.appendix section.level2 > figure > figcaption::before {
+  content: "図" counter(chapter, upper-alpha) "." counter(section) ".-" counter(figure) ": ";
+}
+.appendix section.level3 > figure > figcaption::before {
+  content: "図" counter(chapter, upper-alpha) "." counter(section) "." counter(subsection) ".-" counter(figure) ": ";
+}
+.appendix section.level4 > figure > figcaption::before {
+  content: "図" counter(chapter, upper-alpha) "." counter(section) "." counter(subsection) "." counter(subsubsection) ".-" counter(figure) ": ";
+}
+
+/* 付録の数式番号 */
+.appendix section.level1 > p:has(> .math.display)::after,
+.appendix section.level1 > section.level2 > p:has(> .math.display)::after {
+  content: "(" counter(chapter, upper-alpha) "." counter(section) ".-" counter(equation) ")";
+}
+.appendix section.level3 > p:has(> .math.display)::after {
+  content: "(" counter(chapter, upper-alpha) "." counter(section) "." counter(subsection) ".-" counter(equation) ")";
+}
+.appendix section.level4 > p:has(> .math.display)::after {
+  content: "(" counter(chapter, upper-alpha) "." counter(section) "." counter(subsection) "." counter(subsubsection) ".-" counter(equation) ")";
+}

--- a/src/chapters/97-appendix.md
+++ b/src/chapters/97-appendix.md
@@ -1,0 +1,46 @@
+---
+class: appendix
+body:
+  style: "counter-set: chapter 0;"
+---
+
+<section class="chapter-opening">
+
+<p class="chapter-number">A</p>
+<p class="chapter-title">付録: 参考資料</p>
+
+<div class="chapter-summary">
+
+本付録では、本書で使用した数式や図表の補足資料を掲載する。
+
+</div>
+
+</section>
+
+# 付録: 参考資料
+
+本付録では、補足的な情報を掲載する。
+
+## 数学記号一覧
+
+よく使われる数学記号の例
+
+| 記号 | 名称 | 用途 |
+|------|------|------|
+| $\sum$ | シグマ | 総和 |
+| $\prod$ | パイ | 総乗 |
+| $\int$ | インテグラル | 積分 |
+
+$$
+\sum_{i=1}^{n} i = \frac{n(n+1)}{2}
+$$
+
+## 回路記号一覧
+
+基本的な回路記号を以下に示す。
+
+![LED点滅回路](../assets/diagrams/led-circuit.svg)
+
+## まとめ
+
+本付録では、参考資料として数学記号と回路記号を掲載した。

--- a/vivliostyle.config.js
+++ b/vivliostyle.config.js
@@ -12,6 +12,7 @@ export default {
     'src/chapters/01-introduction.md',
     'src/chapters/02-advanced.md',
     'src/chapters/03-math-and-figures.md',
+    'src/chapters/97-appendix.md',
     'src/chapters/98-afterword.md',
     'src/chapters/99-colophon.md',
   ],


### PR DESCRIPTION
## Summary
- `class: appendix` を指定すると章番号が A, B, C... のアルファベットで表示される機能を追加
- 図番号・表番号・数式番号も自動的にアルファベット形式（例: 図A.-1）に対応
- ページヘッダーの章番号もアルファベット表示に対応
- サンプル付録ファイル（97-appendix.md）を追加
- README に付録の使い方を追記

## 仕組み
- CSS の `counter(chapter, upper-alpha)` を利用
- `.appendix` クラスで通常の数値表示を上書き
- `counter-set: chapter 0` で A、`counter-set: chapter 1` で B に対応

## Test plan
- [ ] PDF をビルドし、付録の章番号が「A. 付録: 参考資料」と表示されることを確認
- [ ] 図番号が「図A.-1」形式で表示されることを確認
- [ ] 数式番号が「(A.1.-1)」形式で表示されることを確認
- [ ] ページヘッダーに「A. 付録: 参考資料」と表示されることを確認
- [ ] 通常の章（1, 2, 3）の番号に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 付録（Appendix）セクションを追加しました。章番号がアルファベット（A、B、C...）で表記されます。
  * 図表や式の番号付けが自動的に付録用フォーマット（例：図A.-1）に切り替わります。
  * 付録セクション向けの新しいスタイルが適用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->