### PR TITLE
fix(theme): 目次の章番号カウントから表紙・目次自体・奥付・あとがきを除外する

### DIFF
--- a/config/themes/techbook/theme.css
+++ b/config/themes/techbook/theme.css
@@ -651,38 +651,46 @@ nav[role="doc-toc"] > ol {
   counter-reset: toc-chapter;
 }
 
-/* まえがき以外の章（data-section-level="1"）にカウンターを適用 */
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])) {
+/* まえがき・あとがき・表紙・目次自体・奥付以外の章（data-section-level="1"）にカウンターを適用 */
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) {
   counter-increment: toc-chapter;
   counter-reset: toc-section;
 }
 
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])) > a::before {
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) > a::before {
   content: counter(toc-chapter) ". ";
 }
 
-/* まえがきの子セクションには番号を付けない */
+/* まえがき・あとがき・表紙・目次自体・奥付の子セクションには番号を付けない */
 nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="preface"]) li[data-section-level="2"] > a::before,
-nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="preface"]) li[data-section-level="3"] > a::before {
+nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="preface"]) li[data-section-level="3"] > a::before,
+nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="afterword"]) li[data-section-level="2"] > a::before,
+nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="afterword"]) li[data-section-level="3"] > a::before,
+nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="cover"]) li[data-section-level="2"] > a::before,
+nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="cover"]) li[data-section-level="3"] > a::before,
+nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="toc"]) li[data-section-level="2"] > a::before,
+nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="toc"]) li[data-section-level="3"] > a::before,
+nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="colophon"]) li[data-section-level="2"] > a::before,
+nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="colophon"]) li[data-section-level="3"] > a::before {
   content: none;
 }
 
 /* 通常の章のセクション */
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])) li[data-section-level="2"] {
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) li[data-section-level="2"] {
   counter-increment: toc-section;
   counter-reset: toc-subsection;
 }
 
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])) li[data-section-level="2"] > a::before {
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) li[data-section-level="2"] > a::before {
   content: counter(toc-chapter) "." counter(toc-section) ". ";
 }
 
 /* 通常の章のサブセクション */
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])) li[data-section-level="3"] {
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) li[data-section-level="3"] {
   counter-increment: toc-subsection;
 }
 
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])) li[data-section-level="3"] > a::before {
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) li[data-section-level="3"] > a::before {
   content: counter(toc-chapter) "." counter(toc-section) "." counter(toc-subsection) ". ";
 }
 

--- a/config/themes/techbook/theme.css
+++ b/config/themes/techbook/theme.css
@@ -652,45 +652,37 @@ nav[role="doc-toc"] > ol {
 }
 
 /* まえがき・あとがき・表紙・目次自体・奥付以外の章（data-section-level="1"）にカウンターを適用 */
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) {
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"], > a[href*="afterword"], > a[href*="cover"], > a[href*="toc"], > a[href*="colophon"])) {
   counter-increment: toc-chapter;
   counter-reset: toc-section;
 }
 
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) > a::before {
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"], > a[href*="afterword"], > a[href*="cover"], > a[href*="toc"], > a[href*="colophon"])) > a::before {
   content: counter(toc-chapter) ". ";
 }
 
 /* まえがき・あとがき・表紙・目次自体・奥付の子セクションには番号を付けない */
-nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="preface"]) li[data-section-level="2"] > a::before,
-nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="preface"]) li[data-section-level="3"] > a::before,
-nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="afterword"]) li[data-section-level="2"] > a::before,
-nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="afterword"]) li[data-section-level="3"] > a::before,
-nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="cover"]) li[data-section-level="2"] > a::before,
-nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="cover"]) li[data-section-level="3"] > a::before,
-nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="toc"]) li[data-section-level="2"] > a::before,
-nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="toc"]) li[data-section-level="3"] > a::before,
-nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="colophon"]) li[data-section-level="2"] > a::before,
-nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="colophon"]) li[data-section-level="3"] > a::before {
+nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="preface"], > a[href*="afterword"], > a[href*="cover"], > a[href*="toc"], > a[href*="colophon"]) li[data-section-level="2"] > a::before,
+nav[role="doc-toc"] li[data-section-level="1"]:has(> a[href*="preface"], > a[href*="afterword"], > a[href*="cover"], > a[href*="toc"], > a[href*="colophon"]) li[data-section-level="3"] > a::before {
   content: none;
 }
 
 /* 通常の章のセクション */
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) li[data-section-level="2"] {
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"], > a[href*="afterword"], > a[href*="cover"], > a[href*="toc"], > a[href*="colophon"])) li[data-section-level="2"] {
   counter-increment: toc-section;
   counter-reset: toc-subsection;
 }
 
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) li[data-section-level="2"] > a::before {
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"], > a[href*="afterword"], > a[href*="cover"], > a[href*="toc"], > a[href*="colophon"])) li[data-section-level="2"] > a::before {
   content: counter(toc-chapter) "." counter(toc-section) ". ";
 }
 
 /* 通常の章のサブセクション */
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) li[data-section-level="3"] {
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"], > a[href*="afterword"], > a[href*="cover"], > a[href*="toc"], > a[href*="colophon"])) li[data-section-level="3"] {
   counter-increment: toc-subsection;
 }
 
-nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"])):not(:has(> a[href*="afterword"])):not(:has(> a[href*="cover"])):not(:has(> a[href*="toc"])):not(:has(> a[href*="colophon"])) li[data-section-level="3"] > a::before {
+nav[role="doc-toc"] li[data-section-level="1"]:not(:has(> a[href*="preface"], > a[href*="afterword"], > a[href*="cover"], > a[href*="toc"], > a[href*="colophon"])) li[data-section-level="3"] > a::before {
   content: counter(toc-chapter) "." counter(toc-section) "." counter(toc-subsection) ". ";
 }
 


### PR DESCRIPTION
## 概要

目次 (`nav[role="doc-toc"]`) の自動採番 CSS が `href*="preface"` の項目しか
章番号カウンター (`toc-chapter`) から除外していなかった問題を修正する．

テンプレート既定の `entry` 構成には `cover.md`／`toc.html` 自身／`98-afterword.md`／
`99-colophon.md` が含まれるため，素の状態で `npm run build` するだけで
目次上の表紙・あとがき・奥付に誤って章番号が振られ，実チャプターの番号がずれる．

除外パターンに `afterword`／`cover`／`toc`／`colophon` を追加し，
それぞれの子セクションにも番号を付けないようにした．

Closes #10

## 動作確認（セルフレビュー実施済み）

このリポジトリ付属のサンプル原稿 (`src/chapters` 配下) で `npm run build`
（2 パスとも）を実行し，生成された `dist/book.pdf` を目視確認した．

- まえがき・表紙・目次自体・あとがき・奥付が章番号なしで目次に並ぶこと．
- 実チャプター（はじめに／応用編／数式と図表）が 1. から連番になること．
- 英語の "Table of Contents" が最終 PDF に含まれないこと．

`dist/`・`index.html`・`src/chapters/*.html`（`toc.html` を除く）・
`package-lock.json` はビルド生成物のため，このコミットには含めていない
（`package-lock.json` は `npm install` 実行に伴う無関係なバージョン差分のため
取り消し済み）．

## 関連

- #10 （本 PR が解消する Issue）
- #11 （ビルドパイプラインの堅牢性に関する別 Issue．本 PR のスコープ外）
- 実運用リポジトリでの同種の指摘・修正: tomio2480/techbook-introduction-to-electronics-basic-led#25